### PR TITLE
Require features to be explicitly enabled

### DIFF
--- a/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -3,10 +3,10 @@ namespace NServiceBus
     public class ServicePlatformConnectionConfiguration
     {
         public ServicePlatformConnectionConfiguration() { }
-        public string AuditQueue { get; set; }
         public NServiceBus.ServicePlatformCustomChecksConfiguration CustomChecks { get; set; }
         public string ErrorQueue { get; set; }
         public NServiceBus.ServicePlatformHeartbeatConfiguration Heartbeats { get; set; }
+        public NServiceBus.ServicePlatformMessageAuditConfiguration MessageAudit { get; set; }
         public NServiceBus.ServicePlatformMetricsConfiguration Metrics { get; set; }
         public NServiceBus.ServicePlatformSagaAuditConfiguration SagaAudit { get; set; }
         public static NServiceBus.ServicePlatformConnectionConfiguration Parse(string jsonConfiguration) { }
@@ -19,18 +19,27 @@ namespace NServiceBus
     {
         public ServicePlatformCustomChecksConfiguration() { }
         public string CustomCheckQueue { get; set; }
+        public bool Enabled { get; set; }
         public System.TimeSpan? TimeToLive { get; set; }
     }
     public class ServicePlatformHeartbeatConfiguration
     {
         public ServicePlatformHeartbeatConfiguration() { }
+        public bool Enabled { get; set; }
         public System.TimeSpan? Frequency { get; set; }
         public string HeartbeatQueue { get; set; }
         public System.TimeSpan? TimeToLive { get; set; }
     }
+    public class ServicePlatformMessageAuditConfiguration
+    {
+        public ServicePlatformMessageAuditConfiguration() { }
+        public string AuditQueue { get; set; }
+        public bool Enabled { get; set; }
+    }
     public class ServicePlatformMetricsConfiguration
     {
         public ServicePlatformMetricsConfiguration() { }
+        public bool Enabled { get; set; }
         public string InstanceId { get; set; }
         public System.TimeSpan Interval { get; set; }
         public string MetricsQueue { get; set; }
@@ -40,6 +49,7 @@ namespace NServiceBus
     {
         public ServicePlatformSagaAuditConfiguration() { }
         public System.Func<object, System.Collections.Generic.Dictionary<string, string>> CustomSagaEntitySerialization { get; set; }
+        public bool Enabled { get; set; }
         public string SagaAuditQueue { get; set; }
     }
 }

--- a/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/BasicUsage.CanBeDeserializedByMicrosoftConfigurationApi.approved.txt
+++ b/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/BasicUsage.CanBeDeserializedByMicrosoftConfigurationApi.approved.txt
@@ -2,6 +2,8 @@
   "errorQueue",
   "MetricsFeature",
   "NServiceBus.AuditConfigReader+Result",
+  "NServiceBus.CustomChecks.CustomChecksFeature",
+  "NServiceBus.CustomChecks.Queue",
   "NServiceBus.Features.SagaAuditFeature",
   "NServiceBus.Heartbeat.HeartbeatsFeature",
   "NServiceBus.Heartbeat.Queue",

--- a/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/BasicUsage.HandlesEnableFlag.CustomChecks.approved.txt
+++ b/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/BasicUsage.HandlesEnableFlag.CustomChecks.approved.txt
@@ -1,0 +1,4 @@
+[
+  "NServiceBus.CustomChecks.CustomChecksFeature",
+  "NServiceBus.CustomChecks.Queue"
+]

--- a/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/BasicUsage.HandlesEnableFlag.Heartbeats.approved.txt
+++ b/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/BasicUsage.HandlesEnableFlag.Heartbeats.approved.txt
@@ -1,0 +1,4 @@
+[
+  "NServiceBus.Heartbeat.HeartbeatsFeature",
+  "NServiceBus.Heartbeat.Queue"
+]

--- a/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/BasicUsage.HandlesEnableFlag.MessageAudit.approved.txt
+++ b/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/BasicUsage.HandlesEnableFlag.MessageAudit.approved.txt
@@ -1,0 +1,3 @@
+[
+  "NServiceBus.AuditConfigReader+Result"
+]

--- a/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/BasicUsage.HandlesEnableFlag.Metrics.approved.txt
+++ b/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/BasicUsage.HandlesEnableFlag.Metrics.approved.txt
@@ -1,0 +1,4 @@
+[
+  "MetricsFeature",
+  "NServiceBus.MetricsOptions"
+]

--- a/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/BasicUsage.HandlesEnableFlag.SagaAudit.approved.txt
+++ b/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/BasicUsage.HandlesEnableFlag.SagaAudit.approved.txt
@@ -1,0 +1,4 @@
+[
+  "NServiceBus.Features.SagaAuditFeature",
+  "NServiceBus.SagaAudit.Queue"
+]

--- a/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/BasicUsage.UpdatesConfiguration.approved.txt
+++ b/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/BasicUsage.UpdatesConfiguration.approved.txt
@@ -2,6 +2,8 @@
   "errorQueue",
   "MetricsFeature",
   "NServiceBus.AuditConfigReader+Result",
+  "NServiceBus.CustomChecks.CustomChecksFeature",
+  "NServiceBus.CustomChecks.Queue",
   "NServiceBus.Features.SagaAuditFeature",
   "NServiceBus.Heartbeat.HeartbeatsFeature",
   "NServiceBus.Heartbeat.Queue",

--- a/src/NServiceBus.ServicePlatform.Connector.UnitTests/BasicUsage.cs
+++ b/src/NServiceBus.ServicePlatform.Connector.UnitTests/BasicUsage.cs
@@ -17,18 +17,25 @@
     class BasicUsage
     {
         const string JsonConfiguration = @"{
-            ""auditQueue"": ""myAuditQueue"",
             ""errorQueue"": ""myErrorQueue"",
             ""heartbeats"": {
+                ""enabled"": true,
                 ""heartbeatQueue"": ""heartbeatsServiceControlQueue""
             },
             ""customChecks"": {
-                ""customChecksQueue"": ""customChecksServiceControlQueue""
+                ""enabled"": true,
+                ""customCheckQueue"": ""customChecksServiceControlQueue""
+            },
+            ""messageAudit"": {
+                ""enabled"": true,
+                ""auditQueue"": ""myAuditQueue""
             },
             ""sagaAudit"": {
+                ""enabled"": true,
                 ""sagaAuditQueue"": ""sagaAuditServiceControlQueue""
             },
             ""metrics"": {
+                ""enabled"": true,
                 ""metricsQueue"": ""metricServiceControlQueue"",
                 ""interval"": ""00:00:10""
             }

--- a/src/NServiceBus.ServicePlatform.Connector.UnitTests/BasicUsage.cs
+++ b/src/NServiceBus.ServicePlatform.Connector.UnitTests/BasicUsage.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.PlatformConnection.UnitTests
 {
+    using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.IO;
@@ -58,6 +59,80 @@
                 .ToArray();
 
             Approver.Verify(changes);
+        }
+
+        static IEnumerable<TestCaseData> OneEnabledFeature
+        {
+            get
+            {
+                var messageAudit = new ServicePlatformConnectionConfiguration
+                {
+                    MessageAudit = new ServicePlatformMessageAuditConfiguration
+                    {
+                        Enabled = true,
+                        AuditQueue = "audit"
+                    }
+                };
+                yield return new TestCaseData("MessageAudit", messageAudit);
+
+                var customChecks = new ServicePlatformConnectionConfiguration
+                {
+                    CustomChecks = new ServicePlatformCustomChecksConfiguration
+                    {
+                        Enabled = true,
+                        CustomCheckQueue = "CustomChecksQueue"
+                    }
+                };
+                yield return new TestCaseData("CustomChecks", customChecks);
+
+                var heartbeats = new ServicePlatformConnectionConfiguration
+                {
+                    Heartbeats = new ServicePlatformHeartbeatConfiguration
+                    {
+                        Enabled = true,
+                        HeartbeatQueue = "HeartbeatQueue"
+                    }
+                };
+                yield return new TestCaseData("Heartbeats", heartbeats);
+
+                var sagaAudit = new ServicePlatformConnectionConfiguration
+                {
+                    SagaAudit = new ServicePlatformSagaAuditConfiguration
+                    {
+                        Enabled = true,
+                        SagaAuditQueue = "SagaAuditQueue"
+                    }
+                };
+                yield return new TestCaseData("SagaAudit", sagaAudit);
+
+                var metrics = new ServicePlatformConnectionConfiguration
+                {
+                    Metrics = new ServicePlatformMetricsConfiguration
+                    {
+                        Enabled = true,
+                        MetricsQueue = "MetricsQueue",
+                        Interval = TimeSpan.FromSeconds(1)
+                    }
+                };
+                yield return new TestCaseData("Metrics", metrics);
+            }
+        }
+
+        [Test, TestCaseSource(nameof(OneEnabledFeature))]
+        public void HandlesEnableFlag(string scenario, ServicePlatformConnectionConfiguration connectionConfig)
+        {
+            var endpointConfig = new EndpointConfiguration("SomeEndpoint");
+
+            var beforeSettings = GetExplicitSettings(endpointConfig);
+
+            endpointConfig.ConnectToServicePlatform(connectionConfig);
+
+            var afterSettings = GetExplicitSettings(endpointConfig);
+            var changes = afterSettings.Except(beforeSettings)
+                .OrderBy(x => x)
+                .ToArray();
+
+            Approver.Verify(changes, scenario: scenario);
         }
 
         [Test]

--- a/src/NServiceBus.ServicePlatform.Connector/ServicePlatformAuditConfiguration.cs
+++ b/src/NServiceBus.ServicePlatform.Connector/ServicePlatformAuditConfiguration.cs
@@ -1,0 +1,48 @@
+﻿namespace NServiceBus
+{
+    using System;
+
+    /// <summary>
+    /// Contains configuration options for the Audit features of the Particular ServicePlatform.
+    /// </summary>
+    public class ServicePlatformMessageAuditConfiguration
+    {
+        ///// <summary>
+        ///// Creates a new <see cref="ServicePlatformMessageAuditConfiguration"/>.
+        ///// </summary>
+        ///// <param name="auditQueue">The queue to send audit messages to.</param>
+        //public ServicePlatformMessageAuditConfiguration(string auditQueue)
+        //{
+        //    Guard.AgainstNullAndEmpty(nameof(auditQueue), auditQueue);
+        //    AuditQueue = auditQueue;
+        //    Enabled = true;
+        //}
+
+        /// <summary>
+        /// If true, the endpoint will send a copy of each message processed to the Particular Service Platform.
+        /// </summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// The transport queue to send Audit message to.
+        /// </summary>
+        public string AuditQueue { get; set; }
+
+        internal void ApplyTo(EndpointConfiguration endpointConfiguration)
+        {
+            if (!Enabled)
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(AuditQueue))
+            {
+                throw new Exception(
+                    @"Message auditing is enabled but no audit queue has been configured.
+Configure an audit queue or disable message auditing");
+            }
+
+            endpointConfiguration.AuditProcessedMessagesTo(AuditQueue);
+        }
+    }
+}

--- a/src/NServiceBus.ServicePlatform.Connector/ServicePlatformAuditConfiguration.cs
+++ b/src/NServiceBus.ServicePlatform.Connector/ServicePlatformAuditConfiguration.cs
@@ -7,17 +7,6 @@
     /// </summary>
     public class ServicePlatformMessageAuditConfiguration
     {
-        ///// <summary>
-        ///// Creates a new <see cref="ServicePlatformMessageAuditConfiguration"/>.
-        ///// </summary>
-        ///// <param name="auditQueue">The queue to send audit messages to.</param>
-        //public ServicePlatformMessageAuditConfiguration(string auditQueue)
-        //{
-        //    Guard.AgainstNullAndEmpty(nameof(auditQueue), auditQueue);
-        //    AuditQueue = auditQueue;
-        //    Enabled = true;
-        //}
-
         /// <summary>
         /// If true, the endpoint will send a copy of each message processed to the Particular Service Platform.
         /// </summary>

--- a/src/NServiceBus.ServicePlatform.Connector/ServicePlatformConnectionConfiguration.cs
+++ b/src/NServiceBus.ServicePlatform.Connector/ServicePlatformConnectionConfiguration.cs
@@ -8,11 +8,6 @@
     public class ServicePlatformConnectionConfiguration
     {
         /// <summary>
-        /// The transport queue to send audit messages to.
-        /// </summary>
-        public string AuditQueue { get; set; }
-
-        /// <summary>
         /// The transport queue to send failed messages to.
         /// </summary>
         public string ErrorQueue { get; set; }
@@ -28,7 +23,12 @@
         public ServicePlatformCustomChecksConfiguration CustomChecks { get; set; }
 
         /// <summary>
-        /// Configuration options for the Saga Audit feature.
+        /// Configuration options for the Message Auditing feature.
+        /// </summary>
+        public ServicePlatformMessageAuditConfiguration MessageAudit { get; set; }
+
+        /// <summary>
+        /// Configuration options for the Saga Auditing feature.
         /// </summary>
         public ServicePlatformSagaAuditConfiguration SagaAudit { get; set; }
 
@@ -39,11 +39,6 @@
 
         internal void ApplyTo(EndpointConfiguration endpointConfiguration)
         {
-            if (string.IsNullOrWhiteSpace(AuditQueue) == false)
-            {
-                endpointConfiguration.AuditProcessedMessagesTo(AuditQueue);
-            }
-
             if (string.IsNullOrWhiteSpace(ErrorQueue) == false)
             {
                 endpointConfiguration.SendFailedMessagesTo(ErrorQueue);
@@ -52,6 +47,7 @@
             Heartbeats?.ApplyTo(endpointConfiguration);
             CustomChecks?.ApplyTo(endpointConfiguration);
             SagaAudit?.ApplyTo(endpointConfiguration);
+            MessageAudit?.ApplyTo(endpointConfiguration);
             Metrics?.ApplyTo(endpointConfiguration);
         }
 

--- a/src/NServiceBus.ServicePlatform.Connector/ServicePlatformCustomChecksConfiguration.cs
+++ b/src/NServiceBus.ServicePlatform.Connector/ServicePlatformCustomChecksConfiguration.cs
@@ -8,6 +8,11 @@
     public class ServicePlatformCustomChecksConfiguration
     {
         /// <summary>
+        /// If true, the endpoint will send custom check results to the Particular Service Platform.
+        /// </summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>
         /// The transport queue to send Custom Checks messages to.
         /// </summary>
         public string CustomCheckQueue { get; set; }
@@ -19,10 +24,19 @@
 
         internal void ApplyTo(EndpointConfiguration endpointConfiguration)
         {
-            if (string.IsNullOrWhiteSpace(CustomCheckQueue) == false)
+            if (!Enabled)
             {
-                endpointConfiguration.ReportCustomChecksTo(CustomCheckQueue, TimeToLive);
+                return;
             }
+
+            if (string.IsNullOrWhiteSpace(CustomCheckQueue))
+            {
+                throw new Exception(
+                    @"Sending custom checks results is enabled but no custom check queue has been configured.
+Configure a custom check queue or disable sending custom checks to the Particular Service Platform");
+            }
+
+            endpointConfiguration.ReportCustomChecksTo(CustomCheckQueue, TimeToLive);
         }
     }
 }

--- a/src/NServiceBus.ServicePlatform.Connector/ServicePlatformHeartbeatConfiguration.cs
+++ b/src/NServiceBus.ServicePlatform.Connector/ServicePlatformHeartbeatConfiguration.cs
@@ -8,6 +8,11 @@
     public class ServicePlatformHeartbeatConfiguration
     {
         /// <summary>
+        /// If true, the endpoint will send heartbeats to the Particular Service Platform.
+        /// </summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>
         /// The transport queue to send Heartbeat messages to.
         /// </summary>
         public string HeartbeatQueue { get; set; }
@@ -24,10 +29,19 @@
 
         internal void ApplyTo(EndpointConfiguration endpointConfiguration)
         {
-            if (string.IsNullOrWhiteSpace(HeartbeatQueue) == false)
+            if (!Enabled)
             {
-                endpointConfiguration.SendHeartbeatTo(HeartbeatQueue, Frequency, TimeToLive);
+                return;
             }
+
+            if (string.IsNullOrWhiteSpace(HeartbeatQueue))
+            {
+                throw new Exception(
+                    @"Sending heartbeats is enabled but no heartbeat queue has been configured.
+Configure a heartbeat queue or disable sending heartbeats to the Particular Service Platform");
+            }
+
+            endpointConfiguration.SendHeartbeatTo(HeartbeatQueue, Frequency, TimeToLive);
         }
     }
 }

--- a/src/NServiceBus.ServicePlatform.Connector/ServicePlatformMetricsConfiguration.cs
+++ b/src/NServiceBus.ServicePlatform.Connector/ServicePlatformMetricsConfiguration.cs
@@ -8,6 +8,11 @@
     public class ServicePlatformMetricsConfiguration
     {
         /// <summary>
+        /// If true, the endpoint will send metric data to the Particular Service Platform.
+        /// </summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>
         /// The transport queue to send Metrics messages to.
         /// </summary>
         public string MetricsQueue { get; set; }
@@ -29,14 +34,23 @@
 
         internal void ApplyTo(EndpointConfiguration endpointConfiguration)
         {
-            if (string.IsNullOrWhiteSpace(MetricsQueue) == false)
+            if (!Enabled)
             {
-                var metrics = endpointConfiguration.EnableMetrics();
-                metrics.SendMetricDataToServiceControl(MetricsQueue, Interval, InstanceId);
-                if (TimeToBeReceived.HasValue)
-                {
-                    metrics.SetServiceControlMetricsMessageTTBR(TimeToBeReceived.Value);
-                }
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(MetricsQueue))
+            {
+                throw new Exception(
+                    @"Sending metric data is enabled but no metrics queue has been configured.
+Configure a metrics queue or disable sending metric data to the Particular Service Platform");
+            }
+
+            var metrics = endpointConfiguration.EnableMetrics();
+            metrics.SendMetricDataToServiceControl(MetricsQueue, Interval, InstanceId);
+            if (TimeToBeReceived.HasValue)
+            {
+                metrics.SetServiceControlMetricsMessageTTBR(TimeToBeReceived.Value);
             }
         }
     }

--- a/src/NServiceBus.ServicePlatform.Connector/ServicePlatformSagaAuditConfiguration.cs
+++ b/src/NServiceBus.ServicePlatform.Connector/ServicePlatformSagaAuditConfiguration.cs
@@ -9,6 +9,11 @@
     public class ServicePlatformSagaAuditConfiguration
     {
         /// <summary>
+        /// If true, the endpoint will audit saga invocations to the Particular Service Platform.
+        /// </summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>
         /// The transport queue to send Saga Audit messages to.
         /// </summary>
         public string SagaAuditQueue { get; set; }
@@ -20,10 +25,20 @@
 
         internal void ApplyTo(EndpointConfiguration endpointConfiguration)
         {
-            if (string.IsNullOrWhiteSpace(SagaAuditQueue) == false)
+            if (!Enabled)
             {
-                endpointConfiguration.AuditSagaStateChanges(SagaAuditQueue, CustomSagaEntitySerialization);
+                return;
             }
+
+            if (string.IsNullOrWhiteSpace(SagaAuditQueue))
+            {
+                throw new Exception(
+                    @"Sending saga audit information is enabled but no saga audit queue has been configured.
+Configure a saga audit queue or disable sending saga audit information to the Particular Service Platform");
+
+            }
+
+            endpointConfiguration.AuditSagaStateChanges(SagaAuditQueue, CustomSagaEntitySerialization);
         }
     }
 }


### PR DESCRIPTION
Adds an explicit `Enabled` flag to each feature instead of using the presence or absence of a configured queue to determine if a feature should light up.

As a part of this change, message auditing was lifted to being a feature.

A minimal json to enable all features looks like this:

```json
{
  "errorQueue": "myErrorQueue",
  "heartbeats": {
    "enabled": true,
    "heartbeatQueue": "heartbeatsServiceControlQueue"
  },
  "customChecks": {
    "enabled": true,
    "customCheckQueue": "customChecksServiceControlQueue"
  },
  "messageAudit": {
    "enabled": true,
    "auditQueue": "myAuditQueue"
  },
  "sagaAudit": {
    "enabled": true,
    "sagaAuditQueue": "sagaAuditServiceControlQueue"
  },
  "metrics": {
    "enabled": true,
    "metricsQueue": "metricServiceControlQueue",
    "interval": "00:00:10"
  }
}
```