### PR TITLE
Allow dependency System.Text.Json in version 7.0.x to be used.

### DIFF
--- a/src/NServiceBus.ServicePlatform.Connector/NServiceBus.ServicePlatform.Connector.csproj
+++ b/src/NServiceBus.ServicePlatform.Connector/NServiceBus.ServicePlatform.Connector.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="[6.0.5, 7.0.0)" />
+    <PackageReference Include="System.Text.Json" Version="6.0.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adjusted dependency to be in line with NServiceBus core package. Therfore reduce dependencies mismatch caused by System.Text.Json.

Ref. Issue https://github.com/Particular/NServiceBus.ServicePlatform.Connector/issues/150