### PR TITLE
Allow dependency System.Text.JSON in version 7.0.x to be used.

### DIFF
--- a/src/NServiceBus.ServicePlatform.Connector/NServiceBus.ServicePlatform.Connector.csproj
+++ b/src/NServiceBus.ServicePlatform.Connector/NServiceBus.ServicePlatform.Connector.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>NServiceBus.ServicePlatform.Connector</PackageId>
-    <Description>Support for connecting NServiceBus endpoints to the Particular Service Plaform</Description>
+    <Description>Support for connecting NServiceBus endpoints to the Particular Service Platform</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.ServicePlatform.Connector/NServiceBus.ServicePlatform.Connector.csproj
+++ b/src/NServiceBus.ServicePlatform.Connector/NServiceBus.ServicePlatform.Connector.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="[6.0.5, 7.0.0)" />
+    <PackageReference Include="System.Text.Json" Version="6.0.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Backport of https://github.com/Particular/NServiceBus.ServicePlatform.Connector/pull/151