### PR TITLE
Metrics configuration wrongly exposes TimeToBeReceived instead of TimeToLive

### DIFF
--- a/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/NServiceBus.ServicePlatform.Connector.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -43,7 +43,11 @@ namespace NServiceBus
         public string InstanceId { get; set; }
         public System.TimeSpan Interval { get; set; }
         public string MetricsQueue { get; set; }
+        [System.Obsolete("Use `TimeToLive` instead. Will be treated as an error from version 4.0.0. Will be" +
+            " removed in version 5.0.0.", false)]
+        [System.Text.Json.Serialization.JsonIgnore]
         public System.TimeSpan? TimeToBeReceived { get; set; }
+        public System.TimeSpan? TimeToLive { get; set; }
     }
     public class ServicePlatformSagaAuditConfiguration
     {

--- a/src/NServiceBus.ServicePlatform.Connector/FodyWeavers.xml
+++ b/src/NServiceBus.ServicePlatform.Connector/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers GenerateXsd="false">
+  <Obsolete HideObsoleteMembers="never" />
+</Weavers>

--- a/src/NServiceBus.ServicePlatform.Connector/NServiceBus.ServicePlatform.Connector.csproj
+++ b/src/NServiceBus.ServicePlatform.Connector/NServiceBus.ServicePlatform.Connector.csproj
@@ -24,7 +24,9 @@
     <PackageReference Include="NServiceBus.Metrics" Version="3.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Label="Private dependencies">
+    <PackageReference Include="Fody" Version="6.8.1" PrivateAssets="All" />
+    <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.ServicePlatform.Connector/ServicePlatformMetricsConfiguration.cs
+++ b/src/NServiceBus.ServicePlatform.Connector/ServicePlatformMetricsConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Contains configuration options for the Metrics features of the Particular Service Platform.
@@ -30,7 +31,21 @@
         /// <summary>
         /// The maximum time to live for Metrics messages.
         /// </summary>
-        public TimeSpan? TimeToBeReceived { get; set; }
+        [ObsoleteEx(
+            TreatAsErrorFromVersion = "4.0.0",
+            RemoveInVersion = "5.0.0",
+            ReplacementTypeOrMember = "TimeToLive")]
+        [JsonIgnore]
+        public TimeSpan? TimeToBeReceived
+        {
+            get => TimeToLive;
+            set => TimeToLive = value;
+        }
+
+        /// <summary>
+        /// The maximum time to live for Metrics messages.
+        /// </summary>
+        public TimeSpan? TimeToLive { get; set; }
 
         internal void ApplyTo(EndpointConfiguration endpointConfiguration)
         {
@@ -48,9 +63,10 @@ Configure a metrics queue or disable sending metric data to the Particular Servi
 
             var metrics = endpointConfiguration.EnableMetrics();
             metrics.SendMetricDataToServiceControl(MetricsQueue, Interval, InstanceId);
-            if (TimeToBeReceived.HasValue)
+
+            if (TimeToLive.HasValue)
             {
-                metrics.SetServiceControlMetricsMessageTTBR(TimeToBeReceived.Value);
+                metrics.SetServiceControlMetricsMessageTTBR(TimeToLive.Value);
             }
         }
     }


### PR DESCRIPTION
- Related to #309
- Backport of #283 

The Metrics configuration, like all the other configuration options, exposes a way to set the metric message time to live.

Instead of using the canonical `TimeToLive` property, it's using `TimeToBeReceived`.

This PR fixes the bug by introducing a new `TimeToLive` property and obsoleting the wrong one.